### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "spatie/laravel-package-tools": "^1.13.0",
-        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0"
+        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",


### PR DESCRIPTION
## Summary
- Add `^13.0` to the `illuminate/contracts` version constraint

## Test plan
- [ ] Verify package installs with Laravel 13
- [ ] Run existing test suite